### PR TITLE
Increase JWT key size to 2048

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,5 @@ ENV/
 
 # Reports
 cobertura.xml
+
+.idea

--- a/package/screwdriver_cd_setup/__init__.py
+++ b/package/screwdriver_cd_setup/__init__.py
@@ -134,7 +134,7 @@ def generate_jwt():
         Dictionary with public_key and private_key
     """
     check_output(
-        ['openssl', 'genrsa', '-out', 'jwt.pem', '1024'], stderr=STDOUT
+        ['openssl', 'genrsa', '-out', 'jwt.pem', '2048'], stderr=STDOUT
     )
     check_output(
         ['openssl', 'rsa', '-in', 'jwt.pem', '-pubout', '-out', 'jwt.pub'],


### PR DESCRIPTION
When Docker Compose is up, GitHub authorization process cannot complete because the JWT key with old length of 1024 results in auth error in browser.