### PR TITLE
Support creating pipeline from GitHub private repo

### DIFF
--- a/package/screwdriver_cd_setup/__init__.py
+++ b/package/screwdriver_cd_setup/__init__.py
@@ -192,6 +192,7 @@ def generate_scm_config(scm_plugin, ip): # pylint: disable=C0103
         client_secret_name = 'Client Secret'
         scm_config['secret'] = 'SUPER-SECRET-SIGNING-THING'
         avatar = 'avatars*.githubusercontent.com'
+        scm_config['privateRepo'] = True
     elif scm_plugin == 'bitbucket':
         service_name = 'Bitbucket.org'
         start_url = 'https://bitbucket.org/account/user/<your username>/oauth-consumers/new'


### PR DESCRIPTION
Cloning private repo is [not supported by default](https://qubitpi.github.io/screwdriver-cd-guide/user-guide/authentication-authorization#:~:text=READ%2DONLY%20access%20to%20public%20repositories), we will need to [enable it by config](https://github.com/screwdriver-cd/screwdriver/issues/436#issuecomment-280169991). 

The [config/custom-environment-variables.yaml](https://github.com/screwdriver-cd/screwdriver/blob/master/config/custom-environment-variables.yaml) has a line:

![page](https://github.com/QubitPi/screwdriver-cd-in-a-box/assets/16126939/84684416-182d-4c4a-8620-01c52a82911c)

This `privateRepo` needs to be put into `SCOM_SETTINGS` object which screwdriver-cd-in-a-box 
make in [`generate_scm_config()` method](https://github.com/QubitPi/screwdriver-cd-in-a-box/blob/master/package/screwdriver_cd_setup/__init__.py)

Thus we only need to [add `privateRepo = true` to `generate_scm_config()`](https://github.com/QubitPi/screwdriver-cd-in-a-box/pull/6/files) so that it will show up in the generated docker-compose.yml:

```yaml
SCM_SETTINGS: |
    {
        "github": {
            "plugin": "github",
            "config": {"username": "...", "email": "...", "secret": "...", "privateRepo": true, "oauthClientId": "...", "oauthClientSecret": "..."}
        }
    }
```